### PR TITLE
feat(JOML): migrate Color

### DIFF
--- a/nui/build.gradle
+++ b/nui/build.gradle
@@ -24,4 +24,12 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
     implementation "org.slf4j:slf4j-api:1.7.30"
+
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
+    testImplementation("junit:junit:4.12")
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/nui/build.gradle
+++ b/nui/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
     implementation "org.slf4j:slf4j-api:1.7.30"
 
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
     testImplementation("junit:junit:4.12")
@@ -32,4 +33,5 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
 }

--- a/nui/src/main/java/org/terasology/nui/Color.java
+++ b/nui/src/main/java/org/terasology/nui/Color.java
@@ -16,6 +16,7 @@
 package org.terasology.nui;
 
 import com.google.common.base.Preconditions;
+import org.joml.Math;
 import org.joml.Vector3fc;
 import org.joml.Vector3ic;
 import org.joml.Vector4fc;
@@ -141,40 +142,40 @@ public class Color implements Colorc{
      * @param g green in the range of 0.0f to 1.0f
      * @param b blue in the range of 0.0f to 1.0f
      */
-    public Color(byte r, byte g, byte b) {
+    public Color(int r, int g, int b) {
         this.set(r, g, b);
     }
 
     /**
      * Creates a color with the given red/green/blue/alpha values.
      *
-     * @param r red in the range of 0.0f to 1.0f
-     * @param g green in the range of 0.0f to 1.0f
-     * @param b blue in the range of 0.0f to 1.0f
-     * @param a alpha in the range of 0.0f to 1.0f
+     * @param r red in the range of 0 to 255
+     * @param g green in the range of 0 to 255
+     * @param b blue in the range of 0 to 255
+     * @param a alpha in the range of 0 to 255
      */
-    public Color(byte r, byte g, byte b, byte a) {
+    public Color(int r, int g, int b, int a) {
         this.set(r, g, b, a);
     }
 
     @Override
-    public byte r() {
-        return (byte) ((representation >> RED_OFFSET) & MAX);
+    public int r() {
+        return (representation >> RED_OFFSET) & MAX;
     }
 
     @Override
-    public byte g() {
-        return (byte) ((representation >> GREEN_OFFSET) & MAX);
+    public int g() {
+        return (representation >> GREEN_OFFSET) & MAX;
     }
 
     @Override
-    public byte b() {
-        return (byte) ((representation >> BLUE_OFFSET) & MAX);
+    public int b() {
+        return (representation >> BLUE_OFFSET) & MAX;
     }
 
     @Override
-    public byte a() {
-        return (byte)(representation & MAX);
+    public int a() {
+        return representation & MAX;
     }
 
     @Override
@@ -230,14 +231,16 @@ public class Color implements Colorc{
         return this;
     }
 
-    public Color set(byte r, byte g, byte b, byte a){
-        representation = r << RED_OFFSET | g << GREEN_OFFSET | b << BLUE_OFFSET | a;
-        return this;
+    public Color set(int r, int g, int b, int a) {
+        return this.set(Math.clamp(0, 255, r) << RED_OFFSET |
+            Math.clamp(0, 255, g) << GREEN_OFFSET |
+            Math.clamp(0, 255, b) << BLUE_OFFSET |
+            Math.clamp(0, 255, a));
     }
 
 
-    public Color set(byte r, byte g, byte b) {
-        return this.set(r, g, b, (byte) 0xFF);
+    public Color set(int r, int g, int b) {
+        return this.set(r, g, b, 0xFF);
     }
 
 
@@ -246,7 +249,7 @@ public class Color implements Colorc{
      * @param value color range between 0-255
      * @return this
      */
-    public Color setRed(byte value) {
+    public Color setRed(int value) {
         return this.set(value << RED_OFFSET | (representation & RED_FILTER));
     }
 
@@ -264,7 +267,7 @@ public class Color implements Colorc{
      * @param value color range between 0-255
      * @return this
      */
-    public Color setGreen(byte value) {
+    public Color setGreen(int value) {
         return this.set(value << GREEN_OFFSET | (representation & GREEN_FILTER));
     }
 
@@ -284,7 +287,7 @@ public class Color implements Colorc{
      * @param value blue range between 0-255
      * @return this
      */
-    public Color setBlue(byte value) {
+    public Color setBlue(int value) {
         return this.set(value << BLUE_OFFSET | (representation & BLUE_FILTER));
     }
 
@@ -302,7 +305,7 @@ public class Color implements Colorc{
      * @param value alpha range between 0-255
      * @return this
      */
-    public Color setAlpha(byte value) {
+    public Color setAlpha(int value) {
         return this.set(value | (representation & ALPHA_FILTER));
     }
 
@@ -320,7 +323,7 @@ public class Color implements Colorc{
      *
      * @param value
      * @return
-     * @deprecated use {@link #setRed(byte)} instead
+     * @deprecated use {@link #setRed(int)} instead
      */
     @Deprecated
     public Color alterRed(int value) {
@@ -332,7 +335,7 @@ public class Color implements Colorc{
      *
      * @param value
      * @return
-     * @deprecated use {@link #setBlue(byte)} instead
+     * @deprecated use {@link #setBlue(int)} instead
      */
     @Deprecated
     public Color alterBlue(int value) {
@@ -344,7 +347,7 @@ public class Color implements Colorc{
      *
      * @param value
      * @return
-     * @deprecated use {@link #setBlue(byte)} instead
+     * @deprecated use {@link #setBlue(int)} instead
      */
     @Deprecated
     public Color alterGreen(int value) {
@@ -355,7 +358,7 @@ public class Color implements Colorc{
     /**
      * @param value
      * @return
-     * @deprecated use {@link #setAlpha(byte)} instead
+     * @deprecated use {@link #setAlpha(int)} instead
      */
     @Deprecated
     public Color alterAlpha(int value) {

--- a/nui/src/main/java/org/terasology/nui/Color.java
+++ b/nui/src/main/java/org/terasology/nui/Color.java
@@ -16,10 +16,11 @@
 package org.terasology.nui;
 
 import com.google.common.base.Preconditions;
+import org.joml.Vector3fc;
+import org.joml.Vector3ic;
+import org.joml.Vector4fc;
+import org.joml.Vector4ic;
 import org.terasology.module.sandbox.API;
-import org.joml.Vector3f;
-import org.joml.Vector3i;
-import org.joml.Vector4f;
 
 import java.nio.ByteBuffer;
 import java.util.Locale;
@@ -41,18 +42,40 @@ import java.util.Objects;
  *
  */
 @API
-public class Color {
+public class Color implements Colorc{
 
+    @Deprecated
     public static final Color BLACK = new Color(0x000000FF);
+    @Deprecated
     public static final Color WHITE = new Color(0xFFFFFFFF);
+    @Deprecated
     public static final Color BLUE = new Color(0x0000FFFF);
+    @Deprecated
     public static final Color GREEN = new Color(0x00FF00FF);
+    @Deprecated
     public static final Color RED = new Color(0xFF0000FF);
+    @Deprecated
     public static final Color GREY = new Color(0x888888FF);
+    @Deprecated
     public static final Color TRANSPARENT = new Color(0x00000000);
+    @Deprecated
     public static final Color YELLOW = new Color(0xFFFF00FF);
+    @Deprecated
     public static final Color CYAN = new Color(0x00FFFFFF);
+    @Deprecated
     public static final Color MAGENTA = new Color(0xFF00FFFF);
+
+    public static final Colorc black = new Color(0x000000FF);
+    public static final Colorc white = new Color(0xFFFFFFFF);
+    public static final Colorc blue = new Color(0x0000FFFF);
+    public static final Colorc green = new Color(0x00FF00FF);
+    public static final Colorc red = new Color(0xFF0000FF);
+    public static final Colorc grey = new Color(0x888888FF);
+    public static final Colorc transparent = new Color(0x00000000);
+    public static final Colorc yellow = new Color(0xFFFF00FF);
+    public static final Colorc cyan = new Color(0x00FFFFFF);
+    public static final Colorc magenta = new Color(0xFF00FFFF);
+
 
     private static final int MAX = 255;
     private static final int RED_OFFSET = 24;
@@ -63,7 +86,7 @@ public class Color {
     private static final int BLUE_FILTER = 0xFFFF00FF;
     private static final int ALPHA_FILTER = 0xFFFFFF00;
 
-    private final int representation;
+    private int representation;
 
     /**
      * Creates a color that is black with full alpha.
@@ -72,144 +95,307 @@ public class Color {
         representation = 0x000000FF;
     }
 
+    /**
+     * range between 0x00000000 to 0xFFFFFFFF
+     * @param representation color in hex format
+     */
     public Color(int representation) {
         this.representation = representation;
     }
 
     /**
+     * set the color source
+     * @param src color source
+     */
+    public Color(Colorc src) {
+        this.set(src.rgba());
+    }
+
+    /**
      * Create a color with the given red/green/blue values. Alpha is initialised as max.
      *
-     * @param r
-     * @param g
-     * @param b
+     * @param r red in the range of 0.0f to 1.0f
+     * @param g green in the range of 0.0f to 1.0f
+     * @param b blue in the range of 0.0f to 1.0f
      */
     public Color(float r, float g, float b) {
-        this((int) (r * MAX), (int) (g * MAX), (int) (b * MAX));
+        this((byte) (r * MAX), (byte) (g * MAX), (byte) (b * MAX));
     }
 
     /**
      * Creates a color with the given red/green/blue/alpha values.
      *
-     * @param r
-     * @param g
-     * @param b
-     * @param a
+     * @param r red in the range of 0.0f to 1.0f
+     * @param g green in the range of 0.0f to 1.0f
+     * @param b blue in the range of 0.0f to 1.0f
+     * @param a alpha in the range of 0.0f to 1.0f
      */
     public Color(float r, float g, float b, float a) {
-        this((int) (r * MAX), (int) (g * MAX), (int) (b * MAX), (int) (a * MAX));
+        this((byte) (r * MAX), (byte) (g * MAX), (byte) (b * MAX), (byte) (a * MAX));
     }
 
     /**
      * Creates a color with the given red/green/blue values. Alpha is initialised as max.
      *
-     * @param r
-     * @param g
-     * @param b
+     * @param r red in the range of 0.0f to 1.0f
+     * @param g green in the range of 0.0f to 1.0f
+     * @param b blue in the range of 0.0f to 1.0f
      */
-    public Color(int r, int g, int b) {
-        this(r, g, b, 0xFF);
+    public Color(byte r, byte g, byte b) {
+        this.set(r, g, b);
     }
 
     /**
      * Creates a color with the given red/green/blue/alpha values.
      *
-     * @param r
-     * @param g
-     * @param b
-     * @param a
+     * @param r red in the range of 0.0f to 1.0f
+     * @param g green in the range of 0.0f to 1.0f
+     * @param b blue in the range of 0.0f to 1.0f
+     * @param a alpha in the range of 0.0f to 1.0f
      */
-    public Color(int r, int g, int b, int a) {
-        Preconditions.checkArgument(r >= 0 && r <= MAX, "Color values must be in range 0-255");
-        Preconditions.checkArgument(g >= 0 && g <= MAX, "Color values must be in range 0-255");
-        Preconditions.checkArgument(b >= 0 && b <= MAX, "Color values must be in range 0-255");
-        Preconditions.checkArgument(a >= 0 && a <= MAX, "Color values must be in range 0-255");
-        representation = r << RED_OFFSET | g << GREEN_OFFSET | b << BLUE_OFFSET | a;
+    public Color(byte r, byte g, byte b, byte a) {
+        this.set(r, g, b, a);
     }
 
-    /**
-     * @return The red component, between 0 and 255
-     */
-    public int r() {
-        return (representation >> RED_OFFSET) & MAX;
+    @Override
+    public byte r() {
+        return (byte) ((representation >> RED_OFFSET) & MAX);
     }
 
-    /**
-     * @return The green component, between 0 and 255
-     */
-    public int g() {
-        return (representation >> GREEN_OFFSET) & MAX;
+    @Override
+    public byte g() {
+        return (byte) ((representation >> GREEN_OFFSET) & MAX);
     }
 
-    /**
-     * @return The blue component, between 0 and 255
-     */
-    public int b() {
-        return (representation >> BLUE_OFFSET) & MAX;
+    @Override
+    public byte b() {
+        return (byte) ((representation >> BLUE_OFFSET) & MAX);
     }
 
-    /**
-     * @return The alpha component, between 0 and 255
-     */
-    public int a() {
-        return representation & MAX;
+    @Override
+    public byte a() {
+        return (byte)(representation & MAX);
     }
 
+    @Override
     public float rf() {
         return r() / 255.f;
     }
 
+    @Override
     public float bf() {
         return b() / 255.f;
     }
 
+    @Override
     public float gf() {
         return g() / 255.f;
     }
 
+    @Override
     public float af() {
         return a() / 255.f;
     }
 
+
+    public Color set(Vector3ic representation) {
+        return this.set((byte) representation.x(),
+            (byte) representation.y(),
+            (byte) representation.z());
+    }
+
+    public Color set(Vector3fc representation) {
+        return this.set((byte) (representation.x() * MAX),
+            (byte) (representation.y() * MAX),
+            (byte) (representation.z() * MAX));
+    }
+
+
+    public Color set(Vector4fc representation) {
+        return this.set((byte) (representation.x() * MAX),
+            (byte) (representation.y() * MAX),
+            (byte) (representation.z() * MAX),
+            (byte) (representation.w() * MAX));
+    }
+
+    public Color set(Vector4ic representation) {
+        return this.set((byte) representation.x(),
+            (byte) representation.y(),
+            (byte) representation.z(),
+            (byte) representation.w());
+    }
+
+    public Color set(int representation){
+        this.representation = representation;
+        return this;
+    }
+
+    public Color set(byte r, byte g, byte b, byte a){
+        representation = r << RED_OFFSET | g << GREEN_OFFSET | b << BLUE_OFFSET | a;
+        return this;
+    }
+
+
+    public Color set(byte r, byte g, byte b) {
+        return this.set(r, g, b, (byte) 0xFF);
+    }
+
+
+    /**
+     * set the value of the red channel
+     * @param value color range between 0-255
+     * @return this
+     */
+    public Color setRed(byte value) {
+        return this.set(value << RED_OFFSET | (representation & RED_FILTER));
+    }
+
+    /**
+     * set the value of the red channel
+     * @param value color range between 0.0f to 1.0f
+     * @return this
+     */
+    public Color setRed(float value) {
+        return setRed((byte) (value * MAX));
+    }
+
+    /**
+     * set the value of the green channel
+     * @param value color range between 0-255
+     * @return this
+     */
+    public Color setGreen(byte value) {
+        return this.set(value << GREEN_OFFSET | (representation & GREEN_FILTER));
+    }
+
+
+    /**
+     * set the value of the green channel
+     * @param value color range between 0.0f to 1.0f
+     * @return this
+     */
+    public Color setGreen(float value) {
+        return setGreen((byte) (value * MAX));
+    }
+
+
+    /**
+     * set the value of the blue channel
+     * @param value blue range between 0-255
+     * @return this
+     */
+    public Color setBlue(byte value) {
+        return this.set(value << BLUE_OFFSET | (representation & BLUE_FILTER));
+    }
+
+    /**
+     * set the value of the blue channel
+     * @param value blue range between 0.0f to 1.0f
+     * @return this
+     */
+    public Color setBlue(float value) {
+        return setBlue((byte) (value * MAX));
+    }
+
+    /**
+     * set the value of the alpha channel
+     * @param value alpha range between 0-255
+     * @return this
+     */
+    public Color setAlpha(byte value) {
+        return this.set(value | (representation & ALPHA_FILTER));
+    }
+
+    /**
+     * set the value of the alpha channel
+     * @param value alpha range between 0.0f to 1.0f
+     * @return this
+     */
+    public Color setAlpha(float value) {
+        return setAlpha((byte) (value * MAX));
+    }
+
+
+    /**
+     *
+     * @param value
+     * @return
+     * @deprecated use {@link #setRed(byte)} instead
+     */
+    @Deprecated
     public Color alterRed(int value) {
         Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << RED_OFFSET | (representation & RED_FILTER));
     }
 
+    /**
+     *
+     * @param value
+     * @return
+     * @deprecated use {@link #setBlue(byte)} instead
+     */
+    @Deprecated
     public Color alterBlue(int value) {
         Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << BLUE_OFFSET | (representation & BLUE_FILTER));
     }
 
+    /**
+     *
+     * @param value
+     * @return
+     * @deprecated use {@link #setBlue(byte)} instead
+     */
+    @Deprecated
     public Color alterGreen(int value) {
         Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value << GREEN_OFFSET | (representation & GREEN_FILTER));
     }
 
+    /**
+     * @param value
+     * @return
+     * @deprecated use {@link #setAlpha(byte)} instead
+     */
+    @Deprecated
     public Color alterAlpha(int value) {
         Preconditions.checkArgument(value >= 0 && value <= MAX, "Color values must be in range 0-255");
         return new Color(value | (representation & ALPHA_FILTER));
     }
 
+    /**
+     * 255 Subtract from all components except alpha
+     * @return new instance of inverted {@link Color}
+     * @deprecated use {@link #invert()} instead
+     */
+    @Deprecated
     public Color inverse() {
         return new Color((~representation & ALPHA_FILTER) | a());
     }
 
+    /**
+     * 255 Subtract from all components except alpha;
+     * @return this
+     */
+    public Color invert() {
+        return this.set((~representation & ALPHA_FILTER) | a());
+    }
+
+    @Override
     public int rgba() {
         return representation;
     }
 
-    public Vector4f toVector4f() {
-        return new Vector4f(rf(), gf(), bf(), af());
+    @Override
+    public int rgb() {
+        return representation | ALPHA_FILTER;
     }
 
-    public Vector3f toVector3f() {
-        return new Vector3f(rf(), gf(), bf());
-    }
-
-    public Vector3i toVector3i() {
-        return new Vector3i(r(), g(), b());
-    }
-
+    /**
+     * write color to ByteBuffer as int.
+     *
+     * @param buffer The ByteBuffer
+     */
     public void addToBuffer(ByteBuffer buffer) {
         buffer.putInt(representation);
     }
@@ -231,6 +417,7 @@ public class Color {
         return Objects.hash(representation);
     }
 
+    @Override
     public String toHex() {
         StringBuilder builder = new StringBuilder();
         String hexString = Integer.toHexString(representation);
@@ -241,27 +428,15 @@ public class Color {
         return builder.toString();
     }
 
-    /**
-     * @param color
-     * @return Slick.Color format representation used in old GUI colorStrings.
-     * Remove after Slick.Color is removed or after colorString format changes.
-     */
-    // TODO: Remove
-    public static String toColorString(Color color) {
-        String hex = color.toHex();
-        String rString = hex.substring(0, 2);
-        String gString = hex.substring(2, 4);
-        String bString = hex.substring(4, 6);
-        String aString = hex.substring(6);
-        return "#" + aString + rString + gString + bString;
-    }
-
-
     @Override
     public String toString() {
         return toHex();
     }
 
+    /**
+     * @deprecated  use {@link #rgba()} instead
+     */
+    @Deprecated
     public int getRepresentation() {
         return representation;
     }

--- a/nui/src/main/java/org/terasology/nui/Color.java
+++ b/nui/src/main/java/org/terasology/nui/Color.java
@@ -391,7 +391,7 @@ public class Color implements Colorc{
 
     @Override
     public int rgb() {
-        return representation | ALPHA_FILTER;
+        return (representation & ALPHA_FILTER) | 0xFF;
     }
 
     /**

--- a/nui/src/main/java/org/terasology/nui/Colorc.java
+++ b/nui/src/main/java/org/terasology/nui/Colorc.java
@@ -21,22 +21,22 @@ public interface Colorc {
     /**
      * @return The red component, between 0 and 255
      */
-    byte r();
+    int r();
 
     /**
      * @return The green component, between 0 and 255
      */
-    byte g();
+    int g();
 
     /**
      * @return The blue component, between 0 and 255
      */
-    byte b();
+    int b();
 
     /**
      * @return The alpha component, between 0 and 255
      */
-    byte a();
+    int a();
 
     /**
      * @return The red channel, between 0.0f and 1.0f

--- a/nui/src/main/java/org/terasology/nui/Colorc.java
+++ b/nui/src/main/java/org/terasology/nui/Colorc.java
@@ -1,0 +1,66 @@
+package org.terasology.nui;
+
+import org.joml.Vector3f;
+
+/**
+ * Interface to a read-only view of a Color.
+ */
+public interface Colorc {
+    /**
+     * The internal representation of the color
+     * @return hex representation
+     */
+    int rgba();
+
+    /**
+     * the internal representation of the color with alpha channel set to 0xFF
+     * @return hex representation
+     */
+    int rgb();
+
+    /**
+     * @return The red component, between 0 and 255
+     */
+    byte r();
+
+    /**
+     * @return The green component, between 0 and 255
+     */
+    byte g();
+
+    /**
+     * @return The blue component, between 0 and 255
+     */
+    byte b();
+
+    /**
+     * @return The alpha component, between 0 and 255
+     */
+    byte a();
+
+    /**
+     * @return The red channel, between 0.0f and 1.0f
+     */
+    float rf();
+
+    /**
+     * @return The green channel, between 0.0f and 1.0f
+     */
+    float gf();
+
+    /**
+     * @return The blue channel, between 0.0f and 1.0f
+     */
+    float bf();
+
+    /**
+     * @return The alpha channel, between 0.0f and 1.0f
+     */
+    float af();
+
+    /**
+     * the hex representation of color as a String
+     * @return the hex representation
+     */
+    String toHex();
+}

--- a/nui/src/test/java/org/terasology/nui/ColorTest.java
+++ b/nui/src/test/java/org/terasology/nui/ColorTest.java
@@ -11,20 +11,42 @@ public class ColorTest {
         Color c1 = new Color(255,0,0);
         Color c2 = new Color(0,255,0);
         Color c3 = new Color(0,0,255);
+        Color c4 = new Color(300,0,255);
 
-        assertEquals(c1.r(),255);
-        assertEquals(c1.g(),0);
-        assertEquals(c1.b(),0);
-        assertEquals(c1, Color.red);
+        assertEquals(255,c1.r());
+        assertEquals(0,c1.g());
+        assertEquals(0,c1.b());
+        assertEquals(255,c1.a());
+        assertEquals(Color.red,c1);
 
         assertEquals(c2.r(),0);
         assertEquals(c2.g(),255);
         assertEquals(c2.b(),0);
-        assertEquals(c1, Color.green);
+        assertEquals(c2.a(),255);
+        assertEquals(Color.green,c2);
 
         assertEquals(c3.r(),0);
         assertEquals(c3.g(),0);
         assertEquals(c3.b(),255);
-        assertEquals(c1, Color.blue);
+        assertEquals(Color.blue, c3);
+
+        assertEquals(c4.r(),255);
+        assertEquals(c4.g(),0);
+        assertEquals(c4.b(),255);
+        assertEquals(c4.a(),255);
+        assertEquals(Color.magenta, c4);
+    }
+
+
+    @Test
+    public void testInvert() {
+        Color c1 = new Color(255,0,0, 155);
+
+        c1.invert();
+
+        assertEquals(0, c1.r());
+        assertEquals(255, c1.g());
+        assertEquals(255, c1.b());
+        assertEquals(155, c1.a());
     }
 }

--- a/nui/src/test/java/org/terasology/nui/ColorTest.java
+++ b/nui/src/test/java/org/terasology/nui/ColorTest.java
@@ -1,0 +1,30 @@
+package org.terasology.nui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ColorTest {
+
+    @Test
+    public void testColor(){
+        Color c1 = new Color(255,0,0);
+        Color c2 = new Color(0,255,0);
+        Color c3 = new Color(0,0,255);
+
+        assertEquals(c1.r(),255);
+        assertEquals(c1.g(),0);
+        assertEquals(c1.b(),0);
+        assertEquals(c1, Color.red);
+
+        assertEquals(c2.r(),0);
+        assertEquals(c2.g(),255);
+        assertEquals(c2.b(),0);
+        assertEquals(c1, Color.green);
+
+        assertEquals(c3.r(),0);
+        assertEquals(c3.g(),0);
+        assertEquals(c3.b(),255);
+        assertEquals(c1, Color.blue);
+    }
+}


### PR DESCRIPTION
This is a rework of how colors work in nui. This is more consistent with JOML. I think this configuration should be easier to use. toVector3f, toVector3i and toVector4f are not used in any of the modules under omega or the engine. If its not used then It would probably be ok to just remove the methods entirely. I also update some of the documentation at the same time. There are some cases I'm probably not considering. 

ref: https://github.com/MovingBlocks/Terasology/pull/4118 