### PR TITLE
chore: prepare multi releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,10 @@ pipeline {
         }
         stage('Publish') {
             when {
-                branch 'master'
+                anyOf {
+                    branch 'master'
+                    branch pattern: "release\/v\d+.x", comparator: "REGEXP"
+                }
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'artifactory-gooey', usernameVariable: 'artifactoryUser', passwordVariable: 'artifactoryPass')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             when {
                 anyOf {
                     branch 'master'
-                    branch pattern: "release\/v\d+.x", comparator: "REGEXP"
+                    branch pattern: "release/v\\d+.x", comparator: "REGEXP"
                 }
             }
             steps {

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ PR with your changes. You can start right away by using the Gitpod online worksp
 
 ## 🤖 Maintenance
 
-**Where do we do the main development?**
-I guess a main branch with the latest code (on gestalt v7)...
+The main development of TeraNUI happens on the `master` branch, a strong main branch that always has the latest version
+of the code. However, we maintain two versions of TeraNUI for [gestalt] v5 and v7, respectively. As the two code lines are nearly identical most changes to either version should be [ported back 🔗](https://docs.microsoft.com/en-us/azure/devops/repos/git/git-branching-guidance?view=azure-devops#port-changes-back-to-the-main-branch) to the other. 
  
-**How do we maintain old versions?**
-I assume there'll be a branch for TeraNUI v1 based on gestalt v5...
+
+| Branch         | Version | gestalt | Projects |
+| -------------- |:-------:|:-------:| -------- |
+| `master`       | v2.x    | v7      | [DestinationSol] |
+| `release/v1.x` | v1.x    | v5      | [Terasology]
 
 **How to back-port changes?** 
 That's a question I'm always asking myself when submitting something to gestalt. I'd like to have a least a rough 
@@ -59,6 +62,8 @@ in [`build.gradle`](./build.gradle).
 The exact build steps for this library are defined in the [Jenkinsfile](./Jenkinsfile).
 
 🗄 [**Snapshots**][artifactory-nui-snapshot] ▪ [**Releases**][artifactory-nui-release]
+
+> 🚧 TODO: how to consume TeraNUI from the Terasolgoy Artifactory (e.g., gradle dependency snippet)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ branches prefixed with `release/v{{major-version}}.x`. The artifact is published
 in [`build.gradle`](./build.gradle).
 
 > ⚠ **Note:** Whether an artifact should be published as release or snapshot is determined by whether or not there is a
-> `-SNAPSHOT` in the version. Publishing will fail in case the same non-snapshot version is supposed to be published
+> `-SNAPSHOT` in the version. Publishing will fail in case publishing the same non-snapshot version is attempted
 > again.
 
 The exact build steps for this library are defined in the [Jenkinsfile](./Jenkinsfile).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Learn more about TeraNUI and how to use it here:
 
 ## 🤓 Development
 
+We welcome contributions to this UI library, be it bug fixes or new features. Feel free to fork this project and open a 
+PR with your changes. You can start right away by using the Gitpod online workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MovingBlocks/TeraNUI)
+
+## 🤖 Maintenance
+
 **Where do we do the main development?**
 I guess a main branch with the latest code (on gestalt v7)...
  
@@ -52,12 +59,6 @@ in [`build.gradle`](./build.gradle).
 The exact build steps for this library are defined in the [Jenkinsfile](./Jenkinsfile).
 
 🗄 [**Snapshots**][artifactory-nui-snapshot] ▪ [**Releases**][artifactory-nui-release]
-
-## Contributors
-
-See [CONTRIBUTORS.md](CONTRIBUTORS.md).
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/MovingBlocks/TeraNUI)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TeraNUI
 
-TeraNUI (Terasology's New UI Framework) is a canvas based UI framework.
+**TeraNUI** (Terasology's New UI Framework) is a canvas based UI framework.
 
 Its major features are:
 
@@ -9,11 +9,49 @@ Its major features are:
 - UIWidget system for encapsulating drawing logic into objects
 - Skin asset providing the ability to define skins
 - UI asset providing the ability to define widget layouts
-- Databinding support
+- Data binding support
 
-## Status
+Learn more about TeraNUI and how to use it here:
 
-Currently in the early stages of being decoupled from Terasology's main repository.
+👉 [JavaDoc] ▪ [Guide] ▪ [Tutorial] 👈
+
+## 🤓 Development
+
+**Where do we do the main development?**
+I guess a main branch with the latest code (on gestalt v7)...
+ 
+**How do we maintain old versions?**
+I assume there'll be a branch for TeraNUI v1 based on gestalt v5...
+
+**How to back-port changes?** 
+That's a question I'm always asking myself when submitting something to gestalt. I'd like to have a least a rough 
+guideline how to backport a change to TeraNUI v1 so that every contributor with write permissions on this repo can do this.
+
+- NUI is tied to a specific version of [gestalt]
+- **v1.x** works with gestalt v5 (compatible with [Terasology])
+- **v2.x** works with gestalt v7 (compatible with [DestinationSol])
+- active development for v2 happens on the `master` branch
+- maintenance of v1 happens the release branch `release/v1`
+- changes and bug-fixes should be ported back to v1
+    - create a new feature branch off the release branch to port the changes
+    - cherry-pick the changes from the main branch to the feature branch
+    - merge the feature branch back into the release branch
+
+
+## 🚀 Release Management
+
+A _release_ denotes that an artifact for the associated commit is available for consumption. Our
+[Jenkins CI/CD pipeline][jenkins] automatically builds and publishes releases for the main `master` branch and release
+branches prefixed with `release/{{version}}`. The artifact is published to our [Artifactory] under the version specified
+in [`build.gradle`](./build.gradle).
+
+> ⚠ **Note:** Whether an artifact should be published as release or snapshot is determined by whether or not there is a
+> `-SNAPSHOT` in the version. Publishing will fail in case the same non-snapshot version is supposed to be published
+> again.
+
+The exact build steps for this library are defined in the [Jenkinsfile](./Jenkinsfile).
+
+🗄 [**Snapshots**][artifactory-nui-snapshot] ▪ [**Releases**][artifactory-nui-release]
 
 ## Contributors
 
@@ -24,3 +62,15 @@ See [CONTRIBUTORS.md](CONTRIBUTORS.md).
 ## License
 
 This library is licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+<!-- References -->
+[gestalt]: https://github.com/MovingBlocks/gestalt
+[terasology]: https://github.com/MovingBlocks/Terasology
+[destinationsol]: https://github.com/MovingBlocks/DestinationSol
+[guide]: https://terasology.org/TeraNUI
+[javadoc]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/job/master/javadoc/overview-summary.html
+[tutorial]: https://github.com/Terasology/TutorialNUI/wiki
+[jenkins]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/
+[artifactory]: http://artifactory.terasology.org/
+[artifactory-nui-snapshot]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-snapshot-local/org/terasology/nui
+[artifactory-nui-release]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-release-local/org/terasology/nui

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ guideline how to backport a change to TeraNUI v1 so that every contributor with 
 
 A _release_ denotes that an artifact for the associated commit is available for consumption. Our
 [Jenkins CI/CD pipeline][jenkins] automatically builds and publishes releases for the main `master` branch and release
-branches prefixed with `release/{{version}}`. The artifact is published to our [Artifactory] under the version specified
+branches prefixed with `release/v{{major-version}}.x`. The artifact is published to our [Artifactory] under the version specified
 in [`build.gradle`](./build.gradle).
 
 > ⚠ **Note:** Whether an artifact should be published as release or snapshot is determined by whether or not there is a

--- a/README.md
+++ b/README.md
@@ -33,20 +33,8 @@ of the code. However, we maintain two versions of TeraNUI for [gestalt] v5 and v
 | `master`       | v2.x    | v7      | [DestinationSol] |
 | `release/v1.x` | v1.x    | v5      | [Terasology]
 
-**How to back-port changes?** 
-That's a question I'm always asking myself when submitting something to gestalt. I'd like to have a least a rough 
-guideline how to backport a change to TeraNUI v1 so that every contributor with write permissions on this repo can do this.
-
-- NUI is tied to a specific version of [gestalt]
-- **v1.x** works with gestalt v5 (compatible with [Terasology])
-- **v2.x** works with gestalt v7 (compatible with [DestinationSol])
-- active development for v2 happens on the `master` branch
-- maintenance of v1 happens the release branch `release/v1`
-- changes and bug-fixes should be ported back to v1
-    - create a new feature branch off the release branch to port the changes
-    - cherry-pick the changes from the main branch to the feature branch
-    - merge the feature branch back into the release branch
-
+Porting changes from one branch to the other should be possible by _cherry picking_ the respective commits as there are
+no differences in the code (yet). **Make sure to adjust the version number to the respective branch when porting a change.**
 
 ## 🚀 Release Management
 
@@ -65,18 +53,59 @@ The exact build steps for this library are defined in the [Jenkinsfile](./Jenkin
 
 > 🚧 TODO: how to consume TeraNUI from the Terasolgoy Artifactory (e.g., gradle dependency snippet)
 
+### Release Process
+
+As releases are automatically triggered from `master` and `release/v{{major-version}}.x` the required steps to make a 
+non-snapshot release for any version is as follows:
+
+1. **Decide on release version** ▪ Which branch to publish, under which version?
+
+    _The version number MUST be a higher SemVer than the current version of the branch to release.
+     The version bump SHOULD follow SemVer specifications, e.g., increase the major version for breaking changes, or do
+     a patch release for bug fixes._
+ 
+1. **Make the release commit** ▪ Trigger a release via [Jenkins]
+
+    _Update the version in [build.gradle](./build.gradle) and remove the `-SNAPSHOT` suffix. Commit the change with the
+     following message:_
+
+    > `release: version {{version}}`
+
+    _Until we have automatic tagging or a tag-based release process it is recommended to manually
+     [create and push an annotated tag][git-tag] for the respective version on `master`. For a library release v1.2.3
+     the tag process is:_
+    
+    ```sh
+    git tag -a v1.2.3 -m "Release version 1.2.3"
+    git push --tags
+    ```
+    
+1. **Prepare for next release** ▪ Bump to next snapshot version
+
+    _Finally, we have to increase the version number to be able to get pre-release `-SNAPSHOT` builds for subsequent 
+     commits. Therefore, the version number MUST be a higher SemVer than the version just released. This will typically
+     be a minor version bump. To do this, just update the version in [build.gradle](./build.gradle) and commit the 
+     change with the following message:_
+    
+    > `chore: prepare next snapshot for {{version}}`
+
+
+> 💚 We try to keep v1 and v2 in sync, thus this relase process should usually be executed for both branches,
+> respectively.
+
 ## License
 
 This library is licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 <!-- References -->
-[gestalt]: https://github.com/MovingBlocks/gestalt
-[terasology]: https://github.com/MovingBlocks/Terasology
-[destinationsol]: https://github.com/MovingBlocks/DestinationSol
-[guide]: https://terasology.org/TeraNUI
-[javadoc]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/job/master/javadoc/overview-summary.html
-[tutorial]: https://github.com/Terasology/TutorialNUI/wiki
-[jenkins]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/
 [artifactory]: http://artifactory.terasology.org/
 [artifactory-nui-snapshot]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-snapshot-local/org/terasology/nui
 [artifactory-nui-release]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-release-local/org/terasology/nui
+[destinationsol]: https://github.com/MovingBlocks/DestinationSol
+[gestalt]: https://github.com/MovingBlocks/gestalt
+[git-tag]: https://www.atlassian.com/git/tutorials/inspecting-a-repository/git-tag
+[guide]: https://terasology.org/TeraNUI
+[javadoc]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/job/master/javadoc/overview-summary.html
+[jenkins]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/
+[terasology]: https://github.com/MovingBlocks/Terasology
+[tutorial]: https://github.com/Terasology/TutorialNUI/wiki


### PR DESCRIPTION
This addresses the outstanding concerns raised in #4. After merging this, we can do a release for **v1.0.0** from the freshly created `release/v1.x` branch 🥳 