### PR TITLE
feat: deep copy of EntityRef.copy (MovingBlocks/Terasology#4099)

### DIFF
--- a/nui-reflect/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
+++ b/nui-reflect/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
@@ -24,7 +24,6 @@ import org.reflections.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.reflection.copy.CopyStrategy;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.InaccessibleFieldException;
 import org.terasology.reflection.reflect.ObjectConstructor;
@@ -39,13 +38,14 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * Class Metadata provides information on a class and its fields, and the ability to create, copy or manipulate an instance of the class.
+ * Class Metadata provides information on a class and its fields, and the ability to create, copy or manipulate an
+ * instance of the class.
  * <br><br>
- * Subclasses can be created to hold additional information for specific types of objects.  These may override createField()
- * to change how fields are processed and possibly switch to a subtype of FieldMetadata that holds additional information.
+ * Subclasses can be created to hold additional information for specific types of objects.  These may override
+ * createField() to change how fields are processed and possibly switch to a subtype of FieldMetadata that holds
+ * additional information.
  * <br><br>
  * Consumed classes are required to have a default constructor (this may be private)
- *
  */
 public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
 
@@ -54,20 +54,21 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
 
     private final ResourceUrn uri;
     private final Class<T> clazz;
-    private final ObjectConstructor<T> constructor;
-    private Map<String, FIELD> fields = Maps.newHashMap();
+    protected final ObjectConstructor<T> constructor;
+    protected Map<String, FIELD> fields = Maps.newHashMap();
     private Map<Byte, FIELD> fieldsById = new HashMap<>();
 
     /**
      * Creates a class metatdata
      *
-     * @param uri                 The uri that identifies this type
-     * @param type                The type to create the metadata for
-     * @param factory             A reflection library to provide class construction and field get/set functionality
+     * @param uri The uri that identifies this type
+     * @param type The type to create the metadata for
+     * @param factory A reflection library to provide class construction and field get/set functionality
      * @param copyStrategyLibrary A copy strategy library
      * @throws NoSuchMethodException If the class has no default constructor
      */
-    public ClassMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory, CopyStrategyLibrary copyStrategyLibrary, Predicate<Field> includedFieldPredicate)
+    public ClassMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory,
+                         CopyStrategyLibrary copyStrategyLibrary, Predicate<Field> includedFieldPredicate)
             throws NoSuchMethodException {
         if (System.getSecurityManager() != null) {
             System.getSecurityManager().checkPermission(CREATE_CLASS_METADATA);
@@ -92,17 +93,17 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
      * Scans the class this metadata describes, adding all fields to the class' metadata.
      *
      * @param copyStrategyLibrary The library of copy strategies
-     * @param factory             The reflection provider
+     * @param factory The reflection provider
      */
-    private void addFields(CopyStrategyLibrary copyStrategyLibrary, ReflectFactory factory, Predicate<Field> includedFieldsPredicate) {
+    private void addFields(CopyStrategyLibrary copyStrategyLibrary, ReflectFactory factory,
+                           Predicate<Field> includedFieldsPredicate) {
         for (Field field : ReflectionUtils.getAllFields(clazz, includedFieldsPredicate)) {
             if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            CopyStrategy<?> copyStrategy = copyStrategyLibrary.getStrategy(field.getGenericType());
 
             try {
-                FIELD metadata = createField(field, copyStrategy, factory);
+                FIELD metadata = createField(field, copyStrategyLibrary, factory);
                 if (metadata != null) {
                     fields.put(metadata.getName().toLowerCase(Locale.ENGLISH), metadata);
                 }
@@ -116,12 +117,13 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
     /**
      * Creates the FieldMetadata describing a field
      *
-     * @param field        The field to create metadata for
-     * @param copyStrategy The copy strategy library
-     * @param factory      The reflection provider
+     * @param field The field to create metadata for
+     * @param copyStrategyLibrary The copy strategy library
+     * @param factory The reflection provider
      * @return A FieldMetadata describing the field, or null to ignore this field
      */
-    protected abstract <V> FIELD createField(Field field, CopyStrategy<V> copyStrategy, ReflectFactory factory) throws InaccessibleFieldException;
+    protected abstract <V> FIELD createField(Field field, CopyStrategyLibrary copyStrategyLibrary,
+                                             ReflectFactory factory) throws InaccessibleFieldException;
 
     /**
      * @return The class described by this metadata
@@ -161,7 +163,8 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
      * @return A new instance of this class.
      */
     public T newInstance() {
-        Preconditions.checkState(isConstructable(), "Cannot construct '" + this + "' - no accessible default constructor");
+        Preconditions.checkState(isConstructable(), "Cannot construct '" + this + "' - no accessible default " +
+                "constructor");
         return constructor.construct();
     }
 
@@ -180,7 +183,8 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
     }
 
     /**
-     * This method is for use in situations where metadata is being used generically and the actual type of the value cannot be
+     * This method is for use in situations where metadata is being used generically and the actual type of the value
+     * cannot be
      *
      * @param object The instance of this class to copy
      * @return A copy of the given object, or null if object is not of the type described by this metadata.
@@ -228,7 +232,7 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
      * Used by FieldMetadata to update the id lookup table
      *
      * @param field The field to update the id for
-     * @param id    The new id of the field
+     * @param id The new id of the field
      */
     @SuppressWarnings("unchecked")
     void setFieldId(FieldMetadata<T, ?> field, byte id) {

--- a/nui-reflect/src/main/java/org/terasology/reflection/metadata/DefaultClassMetadata.java
+++ b/nui-reflect/src/main/java/org/terasology/reflection/metadata/DefaultClassMetadata.java
@@ -17,7 +17,6 @@ package org.terasology.reflection.metadata;
 
 import com.google.common.base.Predicates;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.reflection.copy.CopyStrategy;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.InaccessibleFieldException;
 import org.terasology.reflection.reflect.ReflectFactory;
@@ -26,25 +25,26 @@ import java.lang.reflect.Field;
 
 /**
  * A standard class metadata implementation using FieldMetadata.
- *
  */
 public class DefaultClassMetadata<T> extends ClassMetadata<T, FieldMetadata<T, ?>> {
 
     /**
      * Creates a class metatdata
      *
-     * @param uri                 The uri that identifies this class
-     * @param type                The type to create the metadata for
-     * @param factory             A reflection library to provide class construction and field get/set functionality
+     * @param uri The uri that identifies this class
+     * @param type The type to create the metadata for
+     * @param factory A reflection library to provide class construction and field get/set functionality
      * @param copyStrategyLibrary A copy strategy library
      * @throws NoSuchMethodException If the class has no default constructor
      */
-    public DefaultClassMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory, CopyStrategyLibrary copyStrategyLibrary) throws NoSuchMethodException {
+    public DefaultClassMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory,
+                                CopyStrategyLibrary copyStrategyLibrary) throws NoSuchMethodException {
         super(uri, type, factory, copyStrategyLibrary, Predicates.<Field>alwaysTrue());
     }
 
     @Override
-    protected <V> FieldMetadata<T, V> createField(Field field, CopyStrategy<V> copyStrategy, ReflectFactory factory) throws InaccessibleFieldException {
-        return new FieldMetadata<>(this, field, copyStrategy, factory);
+    protected <V> FieldMetadata<T, V> createField(Field field, CopyStrategyLibrary copyStrategyLibrary,
+                                                  ReflectFactory factory) throws InaccessibleFieldException {
+        return new FieldMetadata<>(this, field, copyStrategyLibrary, factory);
     }
 }

--- a/nui-reflect/src/main/java/org/terasology/reflection/metadata/FieldMetadata.java
+++ b/nui-reflect/src/main/java/org/terasology/reflection/metadata/FieldMetadata.java
@@ -17,11 +17,12 @@ package org.terasology.reflection.metadata;
 
 import com.google.common.base.Objects;
 import com.google.gson.annotations.SerializedName;
+import org.terasology.reflection.ReflectionUtil;
 import org.terasology.reflection.copy.CopyStrategy;
+import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.reflect.FieldAccessor;
 import org.terasology.reflection.reflect.InaccessibleFieldException;
 import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.reflection.ReflectionUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -38,22 +39,23 @@ public class FieldMetadata<T, U> {
     private final Class<U> type;
     private final Field field;
     private final FieldAccessor<T, U> accessor;
-    private final CopyStrategy<U> copyStrategy;
+    protected final CopyStrategy<U> copyStrategy;
 
     private final String serializationName;
 
     private byte id;
 
     /**
-     * @param owner        The ClassMetadata that owns this field
-     * @param field        The field this metadata is for
-     * @param copyStrategy The CopyStrategy appropriate for the type of the field
-     * @param factory      The reflection provider
+     * @param owner The ClassMetadata that owns this field
+     * @param field The field this metadata is for
+     * @param copyStrategyLibrary Something to provide a CopyStrategy appropriate for the type of the field
+     * @param factory The reflection provider
      */
     @SuppressWarnings("unchecked")
-    public FieldMetadata(ClassMetadata<T, ?> owner, Field field, CopyStrategy<U> copyStrategy, ReflectFactory factory) throws InaccessibleFieldException {
+    public FieldMetadata(ClassMetadata<T, ?> owner, Field field, CopyStrategyLibrary copyStrategyLibrary,
+                         ReflectFactory factory) throws InaccessibleFieldException {
         this.owner = owner;
-        this.copyStrategy = copyStrategy;
+        this.copyStrategy = (CopyStrategy<U>) copyStrategyLibrary.getStrategy(field.getGenericType());
         this.type = (Class<U>) determineType(field, owner.getType());
         this.accessor = factory.createFieldAccessor(owner.getType(), field, type);
         this.field = field;
@@ -139,8 +141,8 @@ public class FieldMetadata<T, U> {
     }
 
     /**
-     * Obtains the value of the field from a object which is an instance of the owning type.
-     * This method is checked to conform to the generic parameters of the FieldMetadata
+     * Obtains the value of the field from a object which is an instance of the owning type. This method is checked to
+     * conform to the generic parameters of the FieldMetadata
      *
      * @param from The object to obtain the value of this field from
      * @return The value of the field
@@ -150,8 +152,8 @@ public class FieldMetadata<T, U> {
     }
 
     /**
-     * For types that need to be copied (e.g. Vector3f) for safe usage, this method will create a new copy of a field from an object.
-     * Otherwise it behaves the same as getValue
+     * For types that need to be copied (e.g. Vector3f) for safe usage, this method will create a new copy of a field
+     * from an object. Otherwise it behaves the same as getValue
      *
      * @param from The object to copy the field from
      * @return A safe to use copy of the value of this field in the given object
@@ -161,9 +163,9 @@ public class FieldMetadata<T, U> {
     }
 
     /**
-     * For types that need to be copied (e.g. Vector3f) for safe usage, this method will create a new copy of a field from an object.
-     * Otherwise it behaves the same as getValue
-     * This method is checked to conform to the generic parameters of the FieldMetadata
+     * For types that need to be copied (e.g. Vector3f) for safe usage, this method will create a new copy of a field
+     * from an object. Otherwise it behaves the same as getValue This method is checked to conform to the generic
+     * parameters of the FieldMetadata
      *
      * @param from The object to copy the field from
      * @return A safe to use copy of the value of this field in the given object
@@ -176,7 +178,7 @@ public class FieldMetadata<T, U> {
      * Sets the value of this field in a target object
      *
      * @param target The object to set the field of
-     * @param value  The value to set the field to
+     * @param value The value to set the field to
      */
     @SuppressWarnings("unchecked")
     public void setValue(Object target, Object value) {
@@ -184,11 +186,11 @@ public class FieldMetadata<T, U> {
     }
 
     /**
-     * Sets the value of this field in a target object
-     * This method is checked to conform to the generic parameters of the FieldMetadata
+     * Sets the value of this field in a target object This method is checked to conform to the generic parameters of
+     * the FieldMetadata
      *
      * @param target The object to set the field of
-     * @param value  The value to set the field to
+     * @param value The value to set the field to
      */
     public void setValueChecked(T target, U value) {
         accessor.setValue(target, value);

--- a/nui/src/main/java/org/terasology/nui/reflection/WidgetMetadata.java
+++ b/nui/src/main/java/org/terasology/nui/reflection/WidgetMetadata.java
@@ -17,37 +17,39 @@ package org.terasology.nui.reflection;
 
 import com.google.common.base.Predicate;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.reflection.copy.CopyStrategy;
+import org.terasology.nui.LayoutConfig;
+import org.terasology.nui.UIWidget;
 import org.terasology.reflection.copy.CopyStrategyLibrary;
 import org.terasology.reflection.metadata.ClassMetadata;
 import org.terasology.reflection.metadata.FieldMetadata;
 import org.terasology.reflection.reflect.InaccessibleFieldException;
 import org.terasology.reflection.reflect.ReflectFactory;
-import org.terasology.nui.LayoutConfig;
-import org.terasology.nui.UIWidget;
 
 import java.lang.reflect.Field;
 
 /**
+ *
  */
 public class WidgetMetadata<T extends UIWidget> extends ClassMetadata<T, FieldMetadata<T, ?>> {
 
     /**
      * Creates a class metatdata
      *
-     * @param uri                 The uri that identifies this type
-     * @param type                The type to create the metadata for
-     * @param factory             A reflection library to provide class construction and field get/set functionality
+     * @param uri The uri that identifies this type
+     * @param type The type to create the metadata for
+     * @param factory A reflection library to provide class construction and field get/set functionality
      * @param copyStrategyLibrary A copy strategy library
      * @throws NoSuchMethodException If the class has no default constructor
      */
-    public WidgetMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory, CopyStrategyLibrary copyStrategyLibrary) throws NoSuchMethodException {
+    public WidgetMetadata(ResourceUrn uri, Class<T> type, ReflectFactory factory,
+                          CopyStrategyLibrary copyStrategyLibrary) throws NoSuchMethodException {
         super(uri, type, factory, copyStrategyLibrary, IsConfigField.INSTANCE);
     }
 
     @Override
-    protected <V> FieldMetadata<T, ?> createField(Field field, CopyStrategy<V> copyStrategy, ReflectFactory factory) throws InaccessibleFieldException {
-        return new FieldMetadata<>(this, field, copyStrategy, factory);
+    protected <V> FieldMetadata<T, ?> createField(Field field, CopyStrategyLibrary copyStrategyLibrary,
+                                                  ReflectFactory factory) throws InaccessibleFieldException {
+        return new FieldMetadata<>(this, field, copyStrategyLibrary, factory);
     }
 
     private static class IsConfigField implements Predicate<Field> {


### PR DESCRIPTION
This PR is based on MovingBlocks/Terasology#4099 and ports respective changes to TeraNUI. `CopyStrategyLibrary` is now used over `CopyStrategy` in

- ClassMetadata
- DefaultClassMetadata
- FieldMetadata
- WidgetMetadata