### PR TITLE
fix(v1): Validate and clamp rectangles when created via RectUtility 

### DIFF
--- a/nui/src/main/java/org/terasology/nui/util/NUIMathUtil.java
+++ b/nui/src/main/java/org/terasology/nui/util/NUIMathUtil.java
@@ -33,13 +33,21 @@ public final class NUIMathUtil {
     /**
      * a + b, but if the result exceeds Integer.MAX_VALUE then the result will be Integer.MAX_VALUE rather than overflowing.
      *
-     * @param a
-     * @param b
      * @return min(a + b, Integer.MAX_VALUE)
      */
     public static int addClampAtMax(int a, int b) {
         long result = (long) a + (long) b;
         return (int) Math.min(result, Integer.MAX_VALUE);
+    }
+
+    /**
+     * a + b, but if the result exceeds Float.MAX_VALUE then the result will be Float.MAX_VALUE rather than overflowing.
+     *∂
+     * @return min(a + b, Float.MAX_VALUE)
+     */
+    public static float addClampAtMax(float a, float b) {
+        double result = (double) a + (double) b;
+        return (float) Math.min(result, Float.MAX_VALUE);
     }
 
     /**

--- a/nui/src/main/java/org/terasology/nui/util/RectUtility.java
+++ b/nui/src/main/java/org/terasology/nui/util/RectUtility.java
@@ -10,6 +10,20 @@ public final class RectUtility {
     private RectUtility() {
     }
 
+    /**
+     * Create a 2D axis-aligned rectangle at bottom-left anchor position with given size.
+     *
+     * The result is guaranteed to be valid. If either width or height are negative an empty rectangle is returned.
+     * If creating a rectangle of requested size would exceed the integer range the maximal rectangle that still fits
+     * into the range is returned.
+     *
+     * @param minX the x-coordinate of the bottom-left corner
+     * @param minY the y-coordinate of the bottom-left corner
+     * @param width the width (x-direction)
+     * @param height the height (y-direction)
+     *
+     * @return a 2D axis-aligned rectangle as specified, or an empty rectangle if either width or height are negative
+     */
     public static Rectanglei createFromMinAndSize(int minX, int minY, int width, int height) {
         final int maxX = NUIMathUtil.addClampAtMax(minX, width);
         final int maxY = NUIMathUtil.addClampAtMax(minY, height);
@@ -17,10 +31,35 @@ public final class RectUtility {
         return rect.isValid() ? rect : new Rectanglei();
     }
 
+    /**
+     * Create a 2D axis-aligned rectangle at bottom-left anchor position with given size.
+     *
+     * The result is guaranteed to be valid. If either width or height are negative an empty rectangle is returned.
+     * If creating a rectangle of requested size would exceed the integer range the maximal rectangle that still fits
+     * into the range is returned.
+     *
+     * @param min the coordinates of the bottom-left corner
+     * @param size the size of the rectangle
+     * @return a 2D axis-aligned rectangle as specified, or an empty rectangle if either width or height are negative
+     */
     public static Rectanglei createFromMinAndSize(Vector2i min, Vector2i size) {
         return createFromMinAndSize(min.x, min.y, size.x, size.y);
     }
 
+    /**
+     * Create a 2D axis-aligned rectangle at bottom-left anchor position with given size.
+     *
+     * The result is guaranteed to be valid. If either width or height are negative an empty rectangle is returned.
+     * If creating a rectangle of requested size would exceed the integer range the maximal rectangle that still fits
+     * into the range is returned.
+     *
+     * @param minX the x-coordinate of the bottom-left corner
+     * @param minY the y-coordinate of the bottom-left corner
+     * @param width the width (x-direction)
+     * @param height the height (y-direction)
+     *
+     * @return a 2D axis-aligned rectangle as specified, or an empty rectangle if either width or height are negative
+     */
     public static Rectanglef createFromMinAndSize(float minX, float minY, float width, float height) {
         final float maxX = NUIMathUtil.addClampAtMax(minX, width);
         final float maxY = NUIMathUtil.addClampAtMax(minY, height);
@@ -28,6 +67,17 @@ public final class RectUtility {
         return rect.isValid() ? rect : new Rectanglef();
     }
 
+    /**
+     * Create a 2D axis-aligned rectangle at bottom-left anchor position with given size.
+     *
+     * The result is guaranteed to be valid. If either width or height are negative an empty rectangle is returned.
+     * If creating a rectangle of requested size would exceed the integer range the maximal rectangle that still fits
+     * into the range is returned.
+     *
+     * @param min the coordinates of the bottom-left corner
+     * @param size the size of the rectangle
+     * @return a 2D axis-aligned rectangle as specified, or an empty rectangle if either width or height are negative
+     */
     public static Rectanglef createFromMinAndSize(Vector2f min, Vector2f size) {
         return createFromMinAndSize(min.x, min.y, size.x, size.y);
     }

--- a/nui/src/main/java/org/terasology/nui/util/RectUtility.java
+++ b/nui/src/main/java/org/terasology/nui/util/RectUtility.java
@@ -6,23 +6,30 @@ import org.joml.Vector2f;
 import org.joml.Vector2i;
 
 public final class RectUtility {
+
     private RectUtility() {
     }
 
     public static Rectanglei createFromMinAndSize(int minX, int minY, int width, int height) {
-        return new Rectanglei(minX, minY, minX + width, minY + height);
+        final int maxX = NUIMathUtil.addClampAtMax(minX, width);
+        final int maxY = NUIMathUtil.addClampAtMax(minY, height);
+        final Rectanglei rect = new Rectanglei(minX, minY, maxX, maxY);
+        return rect.isValid() ? rect : new Rectanglei();
     }
 
     public static Rectanglei createFromMinAndSize(Vector2i min, Vector2i size) {
-        return new Rectanglei(min, min.add(size, new Vector2i()));
+        return createFromMinAndSize(min.x, min.y, size.x, size.y);
     }
 
     public static Rectanglef createFromMinAndSize(float minX, float minY, float width, float height) {
-        return new Rectanglef(minX, minY, minX + width, minY + height);
+        final float maxX = NUIMathUtil.addClampAtMax(minX, width);
+        final float maxY = NUIMathUtil.addClampAtMax(minY, height);
+        final Rectanglef rect = new Rectanglef(minX, minY, maxX, maxY);
+        return rect.isValid() ? rect : new Rectanglef();
     }
 
     public static Rectanglef createFromMinAndSize(Vector2f min, Vector2f size) {
-        return new Rectanglef(min, min.add(size, new Vector2f()));
+        return createFromMinAndSize(min.x, min.y, size.x, size.y);
     }
 
     public static Rectanglef createFromCenterAndSize(Vector2f center, Vector2f size) {


### PR DESCRIPTION
If I understand `RectUtility` correctly it is meant as replacement for some convenience methods we have on `Rect2i`/`Rect2f`. However, the semantics of the JOML convenience methods was slightly different, causing tests in https://github.com/MovingBlocks/Terasology/pull/4017 to fail.

---

- **chore: Add math utility `addClampAtMax` for float** · 
	This is required to ensure that RectUtility for Rectanglef works the same way as for Rectanglei.
- **fix: `createFromMinAndSize` clamps and validates result** · 
	On TeraMath classes `Rect2i` and `Rect2f` had the semantics that creating them from min and size would validate that the size is positive along both axis.
	The JOML utility class was missing this feature.

	This also adds overflow prevention.
- **docs: Add JavaDoc for `createFromMinAndMax`** ·
	Adds JavaDoc to explain what the methods are doing and to state contracts and guarantees.

---

Required for https://github.com/MovingBlocks/Terasology/pull/4017

❗  Should be ported back to `master`