### PR TITLE
Fix an int to byte casting issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     // Overall version number for NUI's various elements
-    nuiVersion = "1.2.0-SNAPSHOT"
+    nuiVersion = "1.2.0"
 
     // JOML version we're tracking
     jomlVersion = "1.9.25"

--- a/nui-reflect/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
+++ b/nui-reflect/src/main/java/org/terasology/reflection/metadata/ClassMetadata.java
@@ -135,8 +135,18 @@ public abstract class ClassMetadata<T, FIELD extends FieldMetadata<T, ?>> {
     /**
      * @param id The previously set id of the field
      * @return The field identified by the given id, or null if there is no such field
+     * @deprecated use getField(byte) or change fieldsById to support a larger type if needed
      */
+    @Deprecated
     public FIELD getField(int id) {
+        return getField((byte) id);
+    }
+
+    /**
+     * @param id The previously set id of the field
+     * @return The field identified by the given id, or null if there is no such field
+     */
+    public FIELD getField(byte id) {
         return fieldsById.get(id);
     }
 


### PR DESCRIPTION
Previously when `ClassMetadata` was inside the Terasology engine it used the following collection:

`private TIntObjectMap<FIELD> fieldsById = new TIntObjectHashMap<>();`

In the extracted NUI instead it is:

`private Map<Byte, FIELD> fieldsById = new HashMap<>();`

Not sure why the change was made, but @DarkWeird found that to be the cause of a serialization error when trying to join a Terasology multiplayer server (tiny snippet below, but it is far larger and repeated forever):

```
23:01:47.163 [main] ERROR o.t.p.s.ComponentSerializer - Unable to serialize field 10, out of bounds
23:01:47.163 [main] ERROR o.t.p.s.ComponentSerializer - Unable to serialize field 11, out of bounds
23:01:47.204 [main] ERROR o.t.network.internal.ServerImpl - Updating entity with no network component: EntityRef{id = 0}, expected netId 67
23:01:47.204 [main] ERROR o.t.p.s.ComponentSerializer - Unable to serialize field 0, out of bounds
23:01:47.204 [main] ERROR o.t.p.s.ComponentSerializer - Unable to serialize field 1, out of bounds
```

For now I quick-fixed it by marking the `int` param version of `getField` as deprecated, casting the `int` to a `byte`, and using a new `byte` param variant instead. I don't know if the more proper long term fix is to also sort out all callers to use the `byte` version or if we actually need the `int` (or `short` ?) size for anything.

Have confirmed that it fixes the issue, as did @DarkWeird and it is pretty clear so I'm expediting this along with a release and an engine PR to get everything working again 👍 