### PR TITLE
fix(ModuleTypeRegistry): don't skip merging reflections when possible

### DIFF
--- a/nui-gestalt7/src/main/java/org/terasology/reflection/ModuleTypeRegistry.java
+++ b/nui-gestalt7/src/main/java/org/terasology/reflection/ModuleTypeRegistry.java
@@ -1,5 +1,9 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 package org.terasology.reflection;
 
+import org.reflections.Reflections;
 import org.terasology.gestalt.module.Module;
 import org.terasology.gestalt.module.ModuleEnvironment;
 import org.terasology.gestalt.module.sandbox.ModuleClassLoader;
@@ -20,11 +24,10 @@ public class ModuleTypeRegistry extends TypeRegistry {
         initializeReflections(classLoader, loader -> !(loader instanceof ModuleClassLoader));
 
         for (Module module : environment.getModulesOrderedByDependencies()) {
-            if (module.getClasspaths().size() == 0) {
-                continue;
+            Reflections moduleReflections = module.getModuleManifest();
+            if (moduleReflections != null) {
+                reflections.merge(moduleReflections);
             }
-
-            reflections.merge(module.getModuleManifest());
         }
     }
 }


### PR DESCRIPTION
Modules made with `createPackageModule` can have reflections without knowing what their classpaths are.

I think this change is sufficient to make Terasology's "engine module" work in https://github.com/MovingBlocks/Terasology/pull/4622