### PR TITLE
build: remove `jcenter()`

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -11,8 +11,7 @@ repositories {
     // For development so you can publish binaries locally and have them grabbed from there
     mavenLocal()
 
-    // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
-    jcenter()
+    // External libs
     mavenCentral()
 
     // Used for gestalt 7 - Android annotations


### PR DESCRIPTION
`./gradlew clean build jar --refresh-dependencies --no-build-cache` tested out fine