### PR TITLE
fix(nui-reflect): avoid asking copy strategies to deal with null

### DIFF
--- a/nui-reflect/src/main/java/org/terasology/reflection/metadata/FieldMetadata.java
+++ b/nui-reflect/src/main/java/org/terasology/reflection/metadata/FieldMetadata.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2013 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.reflection.metadata;
 
 import com.google.common.base.Objects;
@@ -159,7 +146,8 @@ public class FieldMetadata<T, U> {
      * @return A safe to use copy of the value of this field in the given object
      */
     public U getCopyOfValue(Object from) {
-        return copyStrategy.copy(getValue(from));
+        U value = getValue(from);
+        return (value != null) ? copyStrategy.copy(value) : null;
     }
 
     /**


### PR DESCRIPTION
CopyStrategy shouldn't need to know how to copy `null`. It's null. Don't call the copy strategy with null.

Blocks https://github.com/MovingBlocks/Terasology/pull/4622