### PR TITLE
build: enable publishing from preview branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
                 anyOf {
                     branch 'master'
                     branch pattern: "release/v\\d+.x", comparator: "REGEXP"
+                    branch pattern: "preview/v\\d+.x", comparator: "REGEXP"
                 }
             }
             steps {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ The following table shows release branches and known projects using them.
 
 We may port back changes made to the main line of the code to release branches by _cherry picking_ them to the respective branches.
 
+In addition to release branches we may prepare _preview branches_ for upcoming and/or experimental features.
+Only `-SNAPSHOT` versions may be released from preview branches.
+It is the responsibility of the preview branch maintainers to keep the preview branches up-to-date with main development.
+
+| Branch         | Version       | gestalt | Projects                             |
+| -------------- |:-------------:|:-------:| ------------------------------------ |
+| `preview/v4.x` | v4.x-SNAPSHOT | \*      | [DestinationSol] experimental branch |
+
 ## 🚀 Release Management
 
 A _release_ denotes that an artifact for the associated commit is available for consumption. Our


### PR DESCRIPTION
Enables automatic publishing from preview branches named `preview/v...`.

NOTE: The publishing step just takes the version as defined by `nuiVersion`  in `build.gradle`. Maintainers need to ensure that only `-SNAPSHOT` versions are published from preview branches.
