### PR TITLE
fix: fix UIButton not releasing when enabled

### DIFF
--- a/nui/src/main/java/org/terasology/nui/widgets/UIButton.java
+++ b/nui/src/main/java/org/terasology/nui/widgets/UIButton.java
@@ -90,7 +90,7 @@ public class UIButton extends ActivatableWidget {
         @Override
         public void onMouseRelease(NUIMouseReleaseEvent event) {
             if (event.getMouseButton() == MouseInput.MOUSE_LEFT) {
-                if (isMouseOver()) {
+                if (isMouseOver() && isEnabled()) {
                     activateWidget();
                 }
                 down = false;
@@ -152,7 +152,7 @@ public class UIButton extends ActivatableWidget {
             canvas.drawTexture(image.get());
         }
         canvas.drawText(text.get());
-        if (isEnabled()) {
+        if (isEnabled() || down) {
             canvas.addInteractionRegion(interactionListener);
         }
     }


### PR DESCRIPTION
If a `UIButton` is disabled whilst the mouse is being held over it, then the `UIButton` will still act as pressed even if the mouse button is released when it is re-enabled. The same applies if you release the button whilst it is disabled. The button only becomes un-pressed when you click it again. I have added a reproduction of this bug to my [NUISamples](https://github.com/BenjaminAmos/NUISamples/blob/f91dc3091499be3c1eec3ddc5e2612471c9ba2b2/samples/src/main/java/org/terasology/nui/samples/ButtonHoldBugSample.java) project. The gif below shows this.
![NUIButtonBug2](https://user-images.githubusercontent.com/24301287/132356386-be090f58-4a05-427e-a6aa-4569b3185e8d.gif)

Destination Sol on Android has several buttons that are used to control the player ship (touch screen controls). These buttons are typically held, rather than pressed, to indicate that an action should be taken (see MovingBlocks/DestinationSol#588). When using NUI buttons to control the player ship, this issue is particually pronouced.

This pull request slightly adjusts the interaction region logic for buttons. It ensures that the interaction region is still present if the button is in the `down` state and then correspondingly only enables the button on mouse release if the button is enabled.