### PR TITLE
build: publish to artifactory.terasology.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ non-snapshot release for any version is as follows:
 This library is licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 <!-- References -->
-[artifactory]: http://artifactory.terasology.org/
-[artifactory-nui-snapshot]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-snapshot-local/org/terasology/nui
-[artifactory-nui-release]: http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/simple/General/libs-release-local/org/terasology/nui
+[artifactory]: https://artifactory.terasology.io/
+[artifactory-nui-snapshot]: https://artifactory.terasology.io/ui/repos/tree/General/libs-snapshot-local/org/terasology/nui
+[artifactory-nui-release]: https://artifactory.terasology.io/ui/repos/tree/General/libs-release-local/org/terasology/nui
 [destinationsol]: https://github.com/MovingBlocks/DestinationSol
 [gestalt]: https://github.com/MovingBlocks/gestalt
 [git-tag]: https://www.atlassian.com/git/tutorials/inspecting-a-repository/git-tag
 [guide]: https://terasology.org/TeraNUI
-[javadoc]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/job/master/javadoc/overview-summary.html
-[jenkins]: http://jenkins.terasology.io/teraorg/job/Libraries/job/TeraNUI/
+[javadoc]: https://jenkins.terasology.io/job/Libraries/job/TeraNUI/job/master/javadoc/overview-summary.html
+[jenkins]: https://jenkins.terasology.io/job/Libraries/job/TeraNUI/
 [terasology]: https://github.com/MovingBlocks/Terasology
 [tutorial]: https://github.com/Terasology/TutorialNUI/wiki

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -30,8 +30,7 @@ repositories {
         } else {
             // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
             name "Terasology Artifactory"
-            url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-            allowInsecureProtocol true  // 😱
+            url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         }
     }
 
@@ -75,11 +74,10 @@ publishing {
             repositories {
                 maven {
                     name = 'TerasologyOrg'
-                    allowInsecureProtocol true // 😱 - no https on our Artifactory yet
 
                     if (rootProject.hasProperty("publishRepo")) {
                         // This first option is good for local testing, you can set a full explicit target repo in gradle.properties
-                        url = "http://artifactory.terasology.org/artifactory/$publishRepo"
+                        url = "https://artifactory.terasology.io/artifactory/$publishRepo"
 
                         logger.info("Changing PUBLISH repoKey set via Gradle property to {}", publishRepo)
                     } else {
@@ -98,7 +96,7 @@ publishing {
                         }
 
                         logger.info("The final deduced publish repo is {}", deducedPublishRepo)
-                        url = "http://artifactory.terasology.org/artifactory/$deducedPublishRepo"
+                        url = "https://artifactory.terasology.io/artifactory/$deducedPublishRepo"
                     }
 
                     if (rootProject.hasProperty("mavenUser") && rootProject.hasProperty("mavenPass")) {


### PR DESCRIPTION
This pull request updates the repository to push artifacts to the newer `artifactory.terasology.io` instance. The latest snapshot artifacts were not being consumed by any projects because they were still being pushed to an older instance. It also uses HTTPS now, which the older one could not.