### PR TITLE
[Preview/v4.x-snapshot] ModuleTypeRegistry type name fixes

### DIFF
--- a/nui-gestalt/src/main/java/org/terasology/reflection/ModuleTypeRegistry.java
+++ b/nui-gestalt/src/main/java/org/terasology/reflection/ModuleTypeRegistry.java
@@ -62,9 +62,9 @@ public class ModuleTypeRegistry extends TypeRegistry {
 
     @Override
     public <T> Set<Class<? extends T>> getSubtypesOf(Class<T> type) {
-        return classIndex.getSubtypesOf(type.toString())
+        return classIndex.getSubtypesOf(type.getName())
                 .stream()
-                .map(ReflectionUtil::forName)
+                .map(className -> ReflectionUtil.forName(className, classLoaders))
                 .map(c -> (Class<? extends T>) c)
                 .collect(Collectors.toSet());
     }
@@ -73,7 +73,7 @@ public class ModuleTypeRegistry extends TypeRegistry {
     public Set<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotationType) {
         return classIndex.getTypesAnnotatedWith(annotationType.getName())
                 .stream()
-                .map(ReflectionUtil::forName)
+                .map(className -> ReflectionUtil.forName(className, classLoaders))
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
This pull request corrects an error in `ModuleTypeRegistry` where the wrong name string was used for a type. `Class#toString` produces an unstable and incorrect string, whereas the value of `Class#getName` was likely expected.

It also fixes an issue where no classes could be found due to not specifying class loaders to look in.