### PR TITLE
fix: null-safety in JsonTreeValue.toString and TextLineBuilder.addText

### DIFF
--- a/nui/src/main/java/org/terasology/nui/TextLineBuilder.java
+++ b/nui/src/main/java/org/terasology/nui/TextLineBuilder.java
@@ -53,6 +53,9 @@ public class TextLineBuilder {
     }
 
     public void addText(String text) {
+        if (text == null) {
+            return;
+        }
         List<String> paragraphs = Arrays.asList(text.split("\\r?\\n", -1));
         for (String paragraph : paragraphs) {
             String remainder = paragraph;

--- a/nui/src/main/java/org/terasology/nui/widgets/treeView/JsonTreeValue.java
+++ b/nui/src/main/java/org/terasology/nui/widgets/treeView/JsonTreeValue.java
@@ -113,9 +113,12 @@ public class JsonTreeValue {
             if (key != null && value != null) {
                 return key + ": " + value;
             }
-            return key == null ? value.toString() : key;
+            if (key != null) {
+                return key;
+            }
+            return value != null ? value.toString() : NULL_STRING;
         } else if (type == Type.VALUE) {
-            return value.toString();
+            return value != null ? value.toString() : NULL_STRING;
         } else if (type == Type.ARRAY) {
             return key != null ? key : ARRAY_STRING;
         } else if (type == Type.OBJECT) {


### PR DESCRIPTION
## Summary
- `JsonTreeValue.toString()` called `value.toString()` for `KEY_VALUE_PAIR` and `VALUE` nodes without checking `value` for null first. A node with no value (e.g. a key-less pair, or a `VALUE` node with nothing set) threw an NPE instead of rendering something sensible. Falls back to the `"null"` literal now, matching the existing `NULL` type branch.
- `TextLineBuilder.addText()` called `text.split(...)` without a null check, so any widget computing a preferred size for a null display string (e.g. `UIList`/`StringTextRenderer`) crashed the whole render pass instead of just rendering no lines.
- Found via a real crash in Terasology's NUI Editor: `NUIEditorItemRenderer.getString()` falls back to `JsonTreeValue.toString()`, which threw an NPE while editing a live JSON tree, and that null then reached `TextLineBuilder.addText` on a different code path too.
- Targets this branch instead of master since it's the one actually consumed by Terasology (`nui-gestalt` project name and `gestalt-module:8.0.0-SNAPSHOT` match exactly what Terasology's dependency graph resolves).

## Test plan
- [x] `gradle :nui:compileJava` succeeds
- [x] Verified against Terasology with this branch (plus nui-gestalt) substituted in via composite build - engine compiles and initializes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)