### PR TITLE
build: raise minimum Java to 17

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -2,8 +2,8 @@ java {
     withSourcesJar()
     withJavadocJar()
 
-    sourceCompatibility(JavaVersion.VERSION_1_8)
-    targetCompatibility(JavaVersion.VERSION_1_8)
+    sourceCompatibility(JavaVersion.VERSION_17)
+    targetCompatibility(JavaVersion.VERSION_17)
 }
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on


### PR DESCRIPTION
build: raise minimum Java to 17

nui-reflect depends on gestalt-inject/gestalt-di, which gestalt is moving to
Java 17 (MovingBlocks/gestalt#163). Gradle's dependency resolution refuses to
let a Java-8-targeted consumer depend on a 17-targeted library at all, so
staying on 8 here would hard-block resolution the moment that gestalt bump
lands - and did, locally, while building against gestalt's in-progress
Java 17 branch as a composite-build dependency.

TeraNUI has no Android target to preserve (unlike gestalt, which keeps
gestalt-android/gestalt-android-testbed on 8 deliberately): no
com.android.* plugin, no Android module directory, and no consumer in the
Terasology workspace builds an Android app against it. The google() Maven
repo entry a few lines down is there to resolve a transitive Android-
annotations artifact some dependency needs, not because TeraNUI itself
targets Android.

Bumping the consumer (17) doesn't break compiling against a not-yet-bumped
dependency (8) - Java's cross-version compatibility only breaks in the other
direction - so this is safe to land independently of #163's merge timing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
