### PR TITLE
build: clear Gradle 10 deprecations, bump wrapper to 9.7.0

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -2,8 +2,8 @@ java {
     withSourcesJar()
     withJavadocJar()
 
-    sourceCompatibility(JavaVersion.VERSION_17)
-    targetCompatibility(JavaVersion.VERSION_17)
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 // We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
@@ -22,22 +22,22 @@ repositories {
         def repoViaEnv = System.getenv()["RESOLUTION_REPO"]
         if (rootProject.hasProperty("alternativeResolutionRepo")) {
             // If the user supplies an alternative repo via gradle.properties then use that
-            name "from alternativeResolutionRepo property"
-            url alternativeResolutionRepo
+            name = "from alternativeResolutionRepo property"
+            url = alternativeResolutionRepo
         } else if (repoViaEnv != null && repoViaEnv != "") {
-            name "from \$RESOLUTION_REPO"
+            name = "from \$RESOLUTION_REPO"
             url = repoViaEnv
         } else {
             // Our default is the main virtual repo containing everything except repos for testing Artifactory itself
-            name "Terasology Artifactory"
-            url "https://artifactory.terasology.io/artifactory/virtual-repo-live"
+            name = "Terasology Artifactory"
+            url = "https://artifactory.terasology.io/artifactory/virtual-repo-live"
         }
     }
 
     maven {
-        name "snowplow (pre-0.9)"
-        url "http://maven.snplow.com/releases"
-        allowInsecureProtocol true  // 😱
+        name = "snowplow (pre-0.9)"
+        url = "http://maven.snplow.com/releases"
+        allowInsecureProtocol = true  // 😱
     }
 }
 
@@ -63,7 +63,7 @@ javadoc {
 }
 
 group = 'org.terasology.nui'
-version = nuiVersion
+version = rootProject.nuiVersion
 
 publishing {
     publications {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/nui-gestalt/build.gradle
+++ b/nui-gestalt/build.gradle
@@ -6,15 +6,15 @@ plugins {
 apply from: "$rootDir/gradle/common.gradle"
 
 dependencies {
-    api group: 'org.terasology.gestalt', name: 'gestalt-module', version: '8.0.0-SNAPSHOT'
-    api group: 'org.terasology.gestalt', name: 'gestalt-asset-core', version: '8.0.0-SNAPSHOT'
-    api group: 'org.terasology.gestalt', name: 'gestalt-di', version: '8.0.0-SNAPSHOT'
+    api "org.terasology.gestalt:gestalt-module:8.0.0-SNAPSHOT"
+    api "org.terasology.gestalt:gestalt-asset-core:8.0.0-SNAPSHOT"
+    api "org.terasology.gestalt:gestalt-di:8.0.0-SNAPSHOT"
 
     annotationProcessor "org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT"
 
     implementation "org.slf4j:slf4j-api:1.7.30"
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
-    implementation group: 'com.google.guava', name: 'guava', version: '23.0'
+    implementation "com.google.code.gson:gson:2.6.2"
+    implementation "com.google.guava:guava:23.0"
 
     api project(':nui')
     api project(':nui-reflect')

--- a/nui-input/build.gradle
+++ b/nui-input/build.gradle
@@ -8,15 +8,15 @@ apply from: "$rootDir/gradle/common.gradle"
 dependencies {
     api ('org.joml:joml') {
         version {
-            require jomlVersion
+            require rootProject.jomlVersion
         }
     }
 
     api ('org.terasology.joml-ext:joml-geometry') {
         version {
-            require geomVersion
+            require rootProject.geomVersion
         }
     }
 
-    implementation group: 'com.google.guava', name: 'guava', version: '23.0'
+    implementation "com.google.guava:guava:23.0"
 }

--- a/nui-reflect/build.gradle
+++ b/nui-reflect/build.gradle
@@ -7,13 +7,13 @@ apply from: "$rootDir/gradle/common.gradle"
 
 dependencies {
     implementation "org.slf4j:slf4j-api:1.7.30"
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
+    implementation "org.reflections:reflections:0.9.10"
+    implementation "com.google.code.gson:gson:2.6.2"
 
-    implementation group: 'com.google.guava', name: 'guava', version: '23.0'
+    implementation "com.google.guava:guava:23.0"
     api ('org.joml:joml') {
         version {
-            require jomlVersion
+            require rootProject.jomlVersion
         }
     }
 
@@ -23,7 +23,7 @@ dependencies {
 
     api ('org.terasology.joml-ext:joml-geometry') {
         version {
-            require geomVersion
+            require rootProject.geomVersion
         }
     }
 }

--- a/nui/build.gradle
+++ b/nui/build.gradle
@@ -6,26 +6,26 @@ plugins {
 apply from: "$rootDir/gradle/common.gradle"
 
 dependencies {
-    api group: 'org.abego.treelayout', name: 'org.abego.treelayout.core', version: '1.0.3'
-    api group: 'com.miglayout', name: 'miglayout-core', version: '5.0'
+    api "org.abego.treelayout:org.abego.treelayout.core:1.0.3"
+    api "com.miglayout:miglayout-core:5.0"
 
     api ('org.joml:joml') {
         version {
-            require jomlVersion
+            require rootProject.jomlVersion
         }
     }
 
     api ('org.terasology.joml-ext:joml-geometry') {
         version {
-            require geomVersion
+            require rootProject.geomVersion
         }
     }
 
     api project(':nui-input')
     api project(':nui-reflect')
 
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.6.2'
-    implementation group: 'org.reflections', name: 'reflections', version: '0.9.10'
+    implementation "com.google.code.gson:gson:2.6.2"
+    implementation "org.reflections:reflections:0.9.10"
     implementation "org.slf4j:slf4j-api:1.7.30"
 
     api "org.terasology.gestalt:gestalt-inject:8.0.0-SNAPSHOT"

--- a/nui/build.gradle
+++ b/nui/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor "org.terasology.gestalt:gestalt-inject-java:8.0.0-SNAPSHOT"
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.6.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.2")
     testImplementation("junit:junit:4.12")


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Clears the Gradle-10-scheduled-for-removal deprecations found building against Gradle 9.7.0: Groovy space-assignment in `gradle/common.gradle`, multi-string dependency notation in each subproject's `build.gradle`, and implicit parent-project property lookups (`nuiVersion`, `jomlVersion`, `geomVersion`).
- Bumps the wrapper from 8.2.1 to 9.7.0 so the warnings are visible at all.

## Test plan

- [x] `./gradlew build -x test --warning-mode=all` — clean of Gradle-10 warnings, BUILD SUCCESSFUL.

## Related

- Companion to MovingBlocks/Terasology#5362 which did the same for the engine repo and flagged gestalt/TeraNUI as needing their own PRs.
